### PR TITLE
4 4 seepex #1736

### DIFF
--- a/Services/GEV/Utils/classes/class.gevOrgUnitUtils.php
+++ b/Services/GEV/Utils/classes/class.gevOrgUnitUtils.php
@@ -743,6 +743,26 @@ class gevOrgUnitUtils {
 		
 		return $orgu->getId();
 	}
+
+	public static function getSuperiorsOfUser($user_id) {
+		global $ilDB;
+
+		$sql = "SELECT DISTINCT sup_users.usr_id FROM object_data orgu
+				INNER JOIN object_reference refr ON refr.obj_id = orgu.obj_id
+				INNER JOIN object_data roles ON roles.title LIKE CONCAT('il_orgu_employee_',refr.ref_id)
+				INNER JOIN rbac_ua rbac ON rbac.usr_id = ".$ilDB->quote($user_id, "integer")." AND roles.obj_id = rbac.rol_id
+				INNER JOIN object_data sup_roles ON sup_roles.title LIKE CONCAT('il_orgu_superior_',refr.ref_id)
+				INNER JOIN rbac_ua sup_users ON sup_users.rol_id = sup_roles.obj_id
+				WHERE orgu.type = 'orgu'";
+
+		$res = $ilDB->query($sql);
+
+		$user_superiors = array();
+		while ($rec = $ilDB->fetchAssoc($res)) {
+			$user_superiors[] = $rec["usr_id"];
+		}
+		return $user_superiors;
+	}
 }
 
 
@@ -786,5 +806,3 @@ class gevOrgUnitCache {
 		return $this->cache[$import_id];
 	}
 }
-
-?>

--- a/Services/GEV/Utils/classes/class.gevUserUtils.php
+++ b/Services/GEV/Utils/classes/class.gevUserUtils.php
@@ -1190,30 +1190,42 @@ class gevUserUtils {
 	
 	public function getDirectSuperiors() {
 		require_once("Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php");
+		require_once("Services/GEV/Utils/classes/class.gevOrgUnitUtils.php");
 		$tree = ilObjOrgUnitTree::_getInstance();
-		$sups = $tree->getSuperiorsOfUser($this->user_id, false);
-		if (count($sups) > 0) {
-			return gevUserUtils::removeInactiveUsers($sups);
-		}
-		// ok, so there are no superiors in any org-unit where the user is employee
-		// we need to find the superiors by ourselves
 		$sups = array();
+		//$sups = gevOrgUnitUtils::getSuperiorsOfUser($this->user_id);
+		$look_above_orgus = array();
 		$orgus = $tree->getOrgUnitOfUser($this->user_id);
-		$parents = array();
-		
-		while (count ($sups) == 0) {
-			foreach ($orgus as $ref) {
-				$parents = $tree->getParent($ref);
+		foreach( $orgus as $ref_id ) {
+			$employees = $tree->getEmployees($ref_id);
+			$superiors = $tree->getSuperiors($ref_id);
+			$any_superiors = count($superiors);
+			if(!$any_superiors) {
+				$look_above_orgus[] = $ref_id; 
+				continue;
 			}
-			if (count($parents) == 0) {
-				return array();
+			if(in_array($this->user_id,$employees)) {
+				$sups = array_merge($sups,$superiors);
+			} else {
+					$look_above_orgus[] = $ref_id;		
 			}
-			$parents = array_unique($parents);
-			foreach ($parents as $ref) {
-				$sups = array_merge($sups, $tree->getSuperiors($ref, false));
+			if(in_array($this->user_id,$superiors)) {
+					$look_above_orgus[] = $ref_id;			
 			}
-			$orgus = $parents;
 		}
+
+		$look_above_orgus = array_unique($look_above_orgus);
+
+		foreach($look_above_orgus as $org) {
+			$sups_aux = array();
+			$org_aux = $org;
+			while (count($sups_aux) == 0 && $org_aux) {
+				$org_aux = $tree->getParent($org_aux);
+				$sups_aux = $tree->getSuperiors($org_aux);
+			}
+			$sups = array_merge($sups,$sups_aux);
+		}
+		$sups = array_unique($sups);
 		return gevUserUtils::removeInactiveUsers($sups);
 	}
 	


### PR DESCRIPTION
Finding direct superiors:

Only superior users in an orgu may be direct superiors of user.
If in some employees orgu there is no superior, look in parent orgu.
If user is superior in orgu a, his direct superior may only be superior member of an orgu above a.
User may be own direct superior.
