### PR TITLE
gev2: #1945 finalize course when mode is not finalized

### DIFF
--- a/Services/ParticipationStatus/classes/class.ilParticipationStatus.php
+++ b/Services/ParticipationStatus/classes/class.ilParticipationStatus.php
@@ -664,7 +664,7 @@ class ilParticipationStatus
 		switch($this->getMode())
 		{
 			case self::MODE_NON_REVIEWED:
-				if($current == self::STATE_SET)
+				if($current != self::STATE_FINALIZED)
 				{
 					$new = self::STATE_FINALIZED;
 				}


### PR DESCRIPTION
Alle Kurse, außer dem "Selbstlernkurs" bekommen den Modus "MODE_NON_REVIEWED".
Dadurch ist der Fehler nicht nur auf Webinare begrenzt.

Lösung ist, den Kurs immer zu finalisieren, es sei denn, er ist es bereits.
Somit verhindert man ein Überschreiben der Daten.
