### PR TITLE
introducing new action menu to admin crs search. logo for memberlist …

### DIFF
--- a/Services/GEV/Desktop/classes/class.gevMyTrainingsAdminTableGUI.php
+++ b/Services/GEV/Desktop/classes/class.gevMyTrainingsAdminTableGUI.php
@@ -162,7 +162,7 @@ class gevMyTrainingsAdminTableGUI extends catAccordionTableGUI {
 	protected function addActionMenu($a_set) {
 		include_once("Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php");
 		$current_selection_list = new ilAdvancedSelectionListGUI();
-		$current_selection_list->setAsynch(true && false);
+		$current_selection_list->setAsynch(true);
 		$current_selection_list->setAsynchUrl(true);
 		$current_selection_list->setListTitle($this->gLng ->txt("actions"));
 		$current_selection_list->setId($a_set["obj_id"]);

--- a/Services/GEV/Desktop/classes/class.gevMyTrainingsApTableGUI.php
+++ b/Services/GEV/Desktop/classes/class.gevMyTrainingsApTableGUI.php
@@ -174,7 +174,7 @@ class gevMyTrainingsApTableGUI extends catAccordionTableGUI {
 	protected function addActionMenu($a_set) {
 		include_once("Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php");
 		$current_selection_list = new ilAdvancedSelectionListGUI();
-		$current_selection_list->setAsynch(true && false);
+		$current_selection_list->setAsynch(true);
 		$current_selection_list->setAsynchUrl(true);
 		$current_selection_list->setListTitle($this->gLng ->txt("actions"));
 		$current_selection_list->setId($a_set["obj_id"]);

--- a/Services/GEV/Desktop/classes/class.ilAdminSearchTableGUI.php
+++ b/Services/GEV/Desktop/classes/class.ilAdminSearchTableGUI.php
@@ -24,9 +24,9 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 
 		global $ilCtrl, $lng, $ilUser;
 
-		$this->lng = &$lng;
-		$this->ctrl = &$ilCtrl;
-		$this->current_user = $ilUser;
+		$this->gLng = &$lng;
+		$this->gCtrl = &$ilCtrl;
+		$this->gUser = $ilUser;
 
 		$this->setEnableTitle(true);
 		$this->setTopCommands(false);
@@ -35,21 +35,21 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 		$this->setExternalSegmentation(true);
 		
 		$this->determineOffsetAndOrder();
-		$this->setFormAction($ilCtrl->getFormAction($a_parent_obj, "view"));
+		$this->setFormAction($this->gCtrl->getFormAction($a_parent_obj, "view"));
 
 		$this->setRowTemplate("tpl.il_admin_search_row.html", "Services/GEV/Desktop");
 
-		$this->addColumn($this->lng->txt("title"), "title");
-		$this->addColumn($this->lng->txt("status"));
-		$this->addColumn($this->lng->txt("gev_course_id"), 'custom_id');
-		$this->addColumn($this->lng->txt("gev_learning_type"), "type");
-		$this->addColumn($this->lng->txt("gev_location"), "location");
-		$this->addColumn($this->lng->txt("date"), "date");
-		$this->addColumn($this->lng->txt("tutor"));
-		$this->addColumn($this->lng->txt("gev_points"), "points");
+		$this->addColumn($this->gLng->txt("title"), "title");
+		$this->addColumn($this->gLng->txt("status"));
+		$this->addColumn($this->gLng->txt("gev_course_id"), 'custom_id');
+		$this->addColumn($this->gLng->txt("gev_learning_type"), "type");
+		$this->addColumn($this->gLng->txt("gev_location"), "location");
+		$this->addColumn($this->gLng->txt("date"), "date");
+		$this->addColumn($this->gLng->txt("tutor"));
+		$this->addColumn($this->gLng->txt("gev_points"), "points");
 		$this->addColumn("&euro;", "fee");
-		$this->addColumn($this->lng->txt("mbrcount"));
-		$this->addColumn($this->lng->txt("actions"), null, "20px", false);
+		$this->addColumn($this->gLng->txt("mbrcount"));
+		$this->addColumn($this->gLng->txt("actions"), null, "20px", false);
 	
 		//legend
 		$this->memberlist_img = '<img src="'.ilUtil::getImagePath("GEV_img/ico-table-eye.png").'" />';
@@ -80,7 +80,7 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 		}
 
 		if ($a_set["start_date"] == null) {
-			$date = $this->lng->txt("gev_table_no_entry");
+			$date = $this->gLng->txt("gev_table_no_entry");
 		}
 		else {
 			$date = ilDatePresentation::formatPeriod($a_set["start_date"], $a_set["end_date"]);
@@ -104,7 +104,7 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 		$current_selection_list = new ilAdvancedSelectionListGUI();
 		$current_selection_list->setAsynch(true);
 		$current_selection_list->setAsynchUrl(true);
-		$current_selection_list->setListTitle($this->lng->txt("actions"));
+		$current_selection_list->setListTitle($this->gLng->txt("actions"));
 		$current_selection_list->setId($a_set["obj_id"]);
 		$current_selection_list->setSelectionHeaderClass("small");
 		$current_selection_list->setItemLinkClass("xsmall");
@@ -126,23 +126,18 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 
 	protected function getActionMenuItems($a_set) {
 		//Prepare links
-		$this->ctrl->setParameterByClass("gevMemberListDeliveryGUI", "ref_id", $a_set["crs_ref_id"]);
-		$memberlist_link = $this->ctrl->getLinkTargetByClass("gevMemberListDeliveryGUI", "trainer");
-		$this->ctrl->clearParametersByClass("gevMemberListDeliveryGUI");
+		$this->gCtrl->setParameterByClass("gevMemberListDeliveryGUI", "ref_id", $a_set["crs_ref_id"]);
+		$memberlist_link = $this->gCtrl->getLinkTargetByClass("gevMemberListDeliveryGUI", "trainer");
+		$this->gCtrl->clearParametersByClass("gevMemberListDeliveryGUI");
 
 		//prepare crs utils
 		$crs_utils = gevCourseUtils::getInstance($a_set["obj_id"]);
 
 		$items = array();
-		if($crs_utils->userHasPermissionTo($this->current_user->getId(), gevSettings::LOAD_MEMBER_LIST)){
-			$items[] = array("title" => $this->lng->txt("gev_mytrainingsap_legend_memberlist"), "link" => $memberlist_link, "image" => $this->memberlist_img, "frame"=>"");
+		if($crs_utils->userHasPermissionTo($this->gUser->getId(), gevSettings::LOAD_MEMBER_LIST)){
+			$items[] = array("title" => $this->gLng->txt("gev_mytrainingsap_legend_memberlist"), "link" => $memberlist_link, "image" => $this->memberlist_img, "frame"=>"");
 		}
-
 
 		return $items;
 	}
-
-	
 }
-
-?>

--- a/Services/GEV/Desktop/classes/class.ilAdminSearchTableGUI.php
+++ b/Services/GEV/Desktop/classes/class.ilAdminSearchTableGUI.php
@@ -102,7 +102,7 @@ class ilAdminSearchTableGUI extends catAccordionTableGUI {
 	protected function addActionMenu($a_set) {
 		include_once("Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php");
 		$current_selection_list = new ilAdvancedSelectionListGUI();
-		$current_selection_list->setAsynch(true && false);
+		$current_selection_list->setAsynch(true);
 		$current_selection_list->setAsynchUrl(true);
 		$current_selection_list->setListTitle($this->lng->txt("actions"));
 		$current_selection_list->setId($a_set["obj_id"]);

--- a/Services/GEV/Utils/classes/class.gevCourseUtils.php
+++ b/Services/GEV/Utils/classes/class.gevCourseUtils.php
@@ -3232,15 +3232,6 @@ class gevCourseUtils {
 			$info[$key]["date"] = $info[$key]["start_date"] .'-' .$info[$key]["end_date"];
 			
 			$info[$key]["status"] = ilObjCourseAccess::_isActivated($value["obj_id"]) ? 'online' : 'offline';
-			$memberlist_img = '<img src="'.ilUtil::getImagePath("GEV_img/ico-table-eye.png").'" />';
-			$memberlist_lnk = "ilias.php?cmd=trainer&cmdClass=gevmemberlistdeliverygui&cmdNode=ei&baseClass=gevmemberlistdeliverygui&ref_id=" .$crs_ref;
-			$action = '<a href="'
-					.$memberlist_lnk
-					.'">'
-					.$memberlist_img
-					.'</a>';
-			$info[$key]["action"] = $action;
-
 		}
 
 		return array("count" => $count, "info" => $info);


### PR DESCRIPTION
…was visible without permission

In der Trainingssuche unter "Verwaltung" wurde das Auge zum Download der Teilnehmerliste immer angezeigt. Da dieses Aktion ja nun ein Recht am Kurs ist, wurde das Auge teilweise fälschlicher Weise angezeigt. Beim Klicken landete man auf der Übersichtsseite.

Das Problem wurde mit dem "cattest-adminansicht" auf der Test gefunden. Ticket #2131!

Dieser PR behebt das Problem und setzt gleichzeitig das neue Aktion Menü um.
