### PR TITLE
2209 userorgu historising, when deleting a local role, dont stop at error …

### DIFF
--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -108,7 +108,7 @@ class ilRbacAdmin
 		if(!$is_global) {
 			require_once "Services/Object/classes/class.ilObjectFactory.php";
 			$obj_fac = new ilObjectFactory;
-			$obj_id = $rbacreview->getObjectOfRole($a_rol_id);
+			$obj_id = $rbacreview->getObjectOfRole($a_rol_id, false);
 
 			if($obj_id) {
 


### PR DESCRIPTION
…when cant find parent objcet. since it was deleted, the case has already been historized
