### PR TITLE
default TUTOR_CFG_MANUALLY for getTutorSource

### DIFF
--- a/Modules/Session/classes/class.ilObjSession.php
+++ b/Modules/Session/classes/class.ilObjSession.php
@@ -965,6 +965,11 @@ class ilObjSession extends ilObject
 	 * @return int
 	 */
 	public function getTutorSource() {
+		// cat-tms-patch start
+		if(is_null($this->tutor_source)) {
+			$this->setTutorSource(self::TUTOR_CFG_MANUALLY);
+		}
+		// cat-tms-patch end
 		return $this->tutor_source;
 	}
 


### PR DESCRIPTION
return TUTOR_CFG_MANUALLY for this->tutor_source==null, so that a session can safely be copied