### PR TITLE
gev_3645 - only show am link in the footer after login

### DIFF
--- a/Services/GEV/Desktop/classes/class.gevFooterLinks.php
+++ b/Services/GEV/Desktop/classes/class.gevFooterLinks.php
@@ -110,7 +110,7 @@ class gevFooterLinks {
 		/*Academy AM*/array
 			( "link" => "./Customizing/global/skin/genv/static/documents/am-akademie.pdf"
 			, "desc" => "gev_footer_academy_am"
-			, "display" => true
+			, "display" => ($uutils instanceof gevUserUtils)
 			)
 		);
 	}


### PR DESCRIPTION
gev_3645
only show am link in the footer after login

https://concepts-and-training.de/bugtracker/view.php?id=3645