### PR TITLE
gev_3653 - set cookie download_started to started in function deliverDate

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -2255,6 +2255,10 @@ class ilUtil
             header('Pragma: public');
 		}
 
+		//gev-patch 3653 do not show pre loader on download
+		ilUtil::setCookie("download_started", "started", false, false, false);
+		//gev-patch end
+
 		header("Connection: close");
 		echo $a_data;
 		exit;


### PR DESCRIPTION
gev_3653
set cookie download_started to started in function deliverDate

https://concepts-and-training.de/bugtracker/view.php?id=3653