### PR TITLE
gev_3647 - rename Suche to Suche/Kompetenzen aus Top-Trainings

### DIFF
--- a/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/GEVCockpit/classes/class.ilGEVCockpitUIHookGUI.php
+++ b/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/GEVCockpit/classes/class.ilGEVCockpitUIHookGUI.php
@@ -371,7 +371,7 @@ class ilGEVCockpitUIHookGUI extends ilUIHookPluginGUI
 	{
 		$items = array
 			( "search"
-				=> array("Suche")
+				=> array("Suche/Kompetenzen aus Top-Trainings")
 			);
 		$crs_search = gevCourseSearch::getInstance($this->target_user_id);
 		$search_tabs = $crs_search->getPossibleTabs();


### PR DESCRIPTION
gev_3647
rename Suche to Suche/Kompetenzen aus Top-Trainings

https://concepts-and-training.de/bugtracker/view.php?id=3647