### PR TITLE
gev_3659 - remove PC- / IT-Kompetenz (AD) from Top Trainings

### DIFF
--- a/Services/GEV/Utils/classes/class.gevSettings.php
+++ b/Services/GEV/Utils/classes/class.gevSettings.php
@@ -374,7 +374,6 @@ class gevSettings
 	const SRTF_SOZIAL_COMP = "Soziale Kompetenz";
 	const SRTF_PERSONAL_COMP = "Persönliche Kompetenz";
 	const SRTF_METHODS_COMP = "Methodenkompetenz";
-	const SRTF_PC_IT_COMP_AD = "PC- / IT-Kompetenz (AD)";
 	const SRTF_PC_IT_COMP_ID = "PC- / IT-Kompetenz (ID)";
 	const SRTF_SPEAK_COMP = "Sprachkompetenz";
 	const SRTF_IMPULS = "Impulsvorträge";
@@ -390,7 +389,6 @@ class gevSettings
 		self::SRTF_SOZIAL_COMP => self::SRTF_SOZIAL_COMP,
 		self::SRTF_PERSONAL_COMP => self::SRTF_PERSONAL_COMP,
 		self::SRTF_METHODS_COMP => self::SRTF_METHODS_COMP,
-		self::SRTF_PC_IT_COMP_AD => self::SRTF_PC_IT_COMP_AD,
 		self::SRTF_PC_IT_COMP_ID => self::SRTF_PC_IT_COMP_ID,
 		self::SRTF_SPEAK_COMP => self::SRTF_SPEAK_COMP,
 		self::SRTF_IMPULS => self::SRTF_IMPULS


### PR DESCRIPTION
gev_3659
remove PC- / IT-Kompetenz (AD) from Top Trainings

https://concepts-and-training.de/bugtracker/view.php?id=3659