### PR TITLE
gev_3675 - remove obsolet setting of tpl var NA_REGISTRATION_LINK

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -369,7 +369,6 @@ class ilStartUpGUI
 		global $tpl;
 		$this->ctrl->setTargetScript("gev_registration.php");
 		$tpl->setVariable('AGENT_REGISTRATION_LINK',$this->ctrl->getLinkTargetByClass(array('gevregistrationgui'),'startAgentRegistration'));
-		$tpl->setVariable('NA_REGISTRATION_LINK',$this->ctrl->getLinkTargetByClass(array('gevregistrationgui'),'startNARegistration'));
 
 		// GEV-Patch start gev_3607
 		$this->ctrl->setTargetScript("pwassist.php");


### PR DESCRIPTION
gev_3675
remove obsolet setting of tpl var NA_REGISTRATION_LINK
https://concepts-and-training.de/bugtracker/view.php?id=3675