### PR TITLE
gev_3668 - remove default selection of checkbox 'Unabhängige Vertriebspartner'

### DIFF
--- a/Services/GEV/DecentralTrainings/classes/class.gevDecentralTrainingGUI.php
+++ b/Services/GEV/DecentralTrainings/classes/class.gevDecentralTrainingGUI.php
@@ -1544,9 +1544,8 @@ class gevDecentralTrainingGUI
 
 		if ($a_form_values["target_groups"] && $a_fill) {
 			$cbx_group_target_groups->setValue($a_form_values["target_groups"]);
-		} else {
-			$cbx_group_target_groups->setValue(array("Unabhängige Vertriebspartner"));
 		}
+
 		$form->addItem($cbx_group_target_groups);
 
 		/*************************


### PR DESCRIPTION
gev_3668
remove default selection of checkbox 'Unabhängige Vertriebspartner'

https://concepts-and-training.de/bugtracker/view.php?id=3668