### PR TITLE
updated lib-ente to v3.1.3

### DIFF
--- a/libs/composer/composer.lock
+++ b/libs/composer/composer.lock
@@ -77,16 +77,16 @@
         },
         {
             "name": "conceptsandtraining/ente",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/conceptsandtraining/lib-ente.git",
-                "reference": "35aea88317aa2f6d43bb4c12dde437fca1232960"
+                "reference": "35d31cb87969670ebee41c0ab708f00f591b9ec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/conceptsandtraining/lib-ente/zipball/35aea88317aa2f6d43bb4c12dde437fca1232960",
-                "reference": "35aea88317aa2f6d43bb4c12dde437fca1232960",
+                "url": "https://api.github.com/repos/conceptsandtraining/lib-ente/zipball/35d31cb87969670ebee41c0ab708f00f591b9ec0",
+                "reference": "35d31cb87969670ebee41c0ab708f00f591b9ec0",
                 "shasum": ""
             },
             "require-dev": {
@@ -109,7 +109,7 @@
                 }
             ],
             "description": "An entity component framework for ILIAS.",
-            "time": "2018-02-21 09:51:11"
+            "time": "2018-07-11 08:21:25"
         },
         {
             "name": "conceptsandtraining/lib-excel-wrapper",

--- a/libs/composer/vendor/composer/autoload_classmap.php
+++ b/libs/composer/vendor/composer/autoload_classmap.php
@@ -2063,6 +2063,7 @@ return array(
     'TCPDF_IMPORT' => $vendorDir . '/tecnickcom/tcpdf/tcpdf_import.php',
     'TCPDF_PARSER' => $vendorDir . '/tecnickcom/tcpdf/tcpdf_parser.php',
     'TCPDF_STATIC' => $vendorDir . '/tecnickcom/tcpdf/include/tcpdf_static.php',
+    'TMSPositionHelper' => $baseDir . '/../../Services/TMS/Positions/TMSPositionHelper.php',
     'TMSTableParentGUI' => $baseDir . '/../../Services/TMS/Table/TMSTableParentGUI.php',
     'TableDiffFormatter' => $baseDir . '/../../Services/COPage/mediawikidiff/class.WordLevelDiff.php',
     'Text_Diff' => $baseDir . '/../../Services/XHTMLValidator/validator/Text_Diff/Diff.php',

--- a/libs/composer/vendor/composer/installed.json
+++ b/libs/composer/vendor/composer/installed.json
@@ -1643,44 +1643,6 @@
         ]
     },
     {
-        "name": "conceptsandtraining/ente",
-        "version": "3.1.2",
-        "version_normalized": "3.1.2.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/conceptsandtraining/lib-ente.git",
-            "reference": "35aea88317aa2f6d43bb4c12dde437fca1232960"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/conceptsandtraining/lib-ente/zipball/35aea88317aa2f6d43bb4c12dde437fca1232960",
-            "reference": "35aea88317aa2f6d43bb4c12dde437fca1232960",
-            "shasum": ""
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^5.6"
-        },
-        "time": "2018-02-21 09:51:11",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "CaT\\Ente\\": "src"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-3.0-or-later"
-        ],
-        "authors": [
-            {
-                "name": "Richard Klees",
-                "email": "richard.klees@concepts-and-training.de"
-            }
-        ],
-        "description": "An entity component framework for ILIAS."
-    },
-    {
         "name": "box/spout",
         "version": "v2.7.3",
         "version_normalized": "2.7.3.0",
@@ -1832,5 +1794,43 @@
             "fpdf",
             "pdf"
         ]
+    },
+    {
+        "name": "conceptsandtraining/ente",
+        "version": "3.1.3",
+        "version_normalized": "3.1.3.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/conceptsandtraining/lib-ente.git",
+            "reference": "35d31cb87969670ebee41c0ab708f00f591b9ec0"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/conceptsandtraining/lib-ente/zipball/35d31cb87969670ebee41c0ab708f00f591b9ec0",
+            "reference": "35d31cb87969670ebee41c0ab708f00f591b9ec0",
+            "shasum": ""
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^5.6"
+        },
+        "time": "2018-07-11 08:21:25",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "CaT\\Ente\\": "src"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-3.0-or-later"
+        ],
+        "authors": [
+            {
+                "name": "Richard Klees",
+                "email": "richard.klees@concepts-and-training.de"
+            }
+        ],
+        "description": "An entity component framework for ILIAS."
     }
 ]

--- a/libs/composer/vendor/conceptsandtraining/ente/composer.json
+++ b/libs/composer/vendor/conceptsandtraining/ente/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "conceptsandtraining/ente",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "description": "An entity component framework for ILIAS.",
     "type": "library",
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
New version of lib-ente can deal with situations where `ilObjects` could not be created due to some reason.

https://concepts-and-training.pixsoftware.de/jira/browse/TMS-1622
https://concepts-and-training.pixsoftware.de/jira/browse/TMS-1623 